### PR TITLE
Obtain license name from `package.json` instead of hardcoding

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,7 +24,7 @@ function getAuthors(pkg) {
 const banner = `/*!
   * ${pkg.name} v${pkg.version}
   * (c) ${new Date().getFullYear()} ${getAuthors(pkg)}
-  * @license MIT
+  * @license ${pkg.license}
   */`
 
 // ensure TS checks only once for each build


### PR DESCRIPTION
The `license` field in the `package.json` file should contain the license name. That should be used instead of hardcoding it to 'MIT'.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#Pull-Request
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->
<!-- Tip: publish the PR and check the checkboxes by simply clicking on them -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
